### PR TITLE
feat(cmd): implement CLI feedback loop

### DIFF
--- a/cmd/ranan/main.go
+++ b/cmd/ranan/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/kaidi-ahas/ranan/internal/pitch"
+)
+
+func main() {
+	sampleRate := 44100
+	frequency := 440.0
+	frameSize := 2048
+
+	samples := make([]float64, frameSize)
+	for i := 0; i < frameSize; i++ {
+		samples[i] = math.Sin(2 * math.Pi * frequency * float64(i) / float64(sampleRate))
+	}
+
+	frame := pitch.Frame{
+		Samples:    samples,
+		SampleRate: sampleRate,
+	}
+
+	analysis := pitch.Analyse(frame)
+
+	fmt.Printf("Frequency: %.2f Hz\n", analysis.Pitch.Frequency)
+	fmt.Printf("Note:      %s%d\n", analysis.Note.Name, analysis.Note.Octave)
+	fmt.Printf("Cents:     %.2f\n", analysis.Note.Cents)
+}


### PR DESCRIPTION
Closes #11 

## What this does
- Adds cmd/ranan/main.go as a separate CLI entry point
- Generates a 440 Hz sine wave frame
- Passes frame through full Analyse() pipeline
- Prints frequency, note name, octave, and cent deviation

## Output
Frequency:    441.00 Hz
Note:              A4
Cents:            3.93