### PR TITLE
feat(arduino): add LED tuner firmware for serial pitch display

### DIFF
--- a/arduino/tuner/tuner.ino
+++ b/arduino/tuner/tuner.ino
@@ -1,0 +1,39 @@
+const int PIN_LED_LEFT  = 10;
+const int PIN_LED_GREEN = 11;
+const int PIN_LED_RIGHT = 12;
+
+const float TUNE_THRESHOLD = 10.0;
+
+void setup() {
+    Serial.begin(9600);
+    pinMode(PIN_LED_LEFT,  OUTPUT);
+    pinMode(PIN_LED_GREEN, OUTPUT);
+    pinMode(PIN_LED_RIGHT, OUTPUT);
+}
+
+void loop() {
+    if (Serial.available() > 0) {
+        String message = Serial.readStringUntil('\n');
+        message.trim();
+
+        int commaIndex = message.indexOf(',');
+        if (commaIndex == -1) {
+            return;
+        }
+
+        String noteStr = message.substring(0, commaIndex);
+        float cents    = message.substring(commaIndex + 1).toFloat();
+
+        digitalWrite(PIN_LED_LEFT,  LOW);
+        digitalWrite(PIN_LED_GREEN, LOW);
+        digitalWrite(PIN_LED_RIGHT, LOW);
+
+        if (cents < -TUNE_THRESHOLD) {
+            digitalWrite(PIN_LED_LEFT, HIGH);
+        } else if (cents > TUNE_THRESHOLD) {
+            digitalWrite(PIN_LED_RIGHT, HIGH);
+        } else {
+            digitalWrite(PIN_LED_GREEN, HIGH);
+        }
+    }
+}


### PR DESCRIPTION
Closes #22 

## What this does
- Adds Arduino firmware that receives serial messages from the CLI
- Parses note name and cent deviation from the message format `A4,0.79`
- Lights left LED when pitch is flat beyond threshold
- Lights right LED when pitch is sharp beyond threshold
- Lights green LED when pitch is within tune threshold (±10 cents)