### PR TITLE
feat(cmd): implement tuner mode with --tuner and --threshold flags

### DIFF
--- a/cmd/ranan/main.go
+++ b/cmd/ranan/main.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bufio"
+	"flag"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/kaidi-ahas/ranan/internal/audio"
@@ -14,12 +18,14 @@ import (
 )
 
 const (
-	bufferSize = 5
+	bufferSize  = 5
 	arduinoPort = "/dev/cu.usbmodem11301"
 )
 
 func main() {
-	fmt.Println("Listening... (Ctrl+C to stop)")
+	tunerMode := flag.Bool("tuner", false, "enable tuner mode")
+	threshold := flag.Float64("threshold", 10.0, "in-tune threshold in cents")
+	flag.Parse()
 
 	mic, err := audio.NewMicrophone()
 	if err != nil {
@@ -29,40 +35,38 @@ func main() {
 
 	port, err := serial.Open(arduinoPort)
 	if err != nil {
-		log.Fatalf("failed to open serial port: %v", err)
+		log.Printf("warning: Arduino not connected, serial disabled: %v", err)
+		port = nil
 	}
-	defer port.Close()
+	if port != nil {
+		defer port.Close()
+	}
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
 	buf := pitch.NewBuffer(bufferSize)
 
+	if *tunerMode {
+		runTunerMode(mic, buf, port, stop, *threshold)
+	} else {
+		runFreeMode(mic, buf, port, stop)
+	}
+}
+
+func runFreeMode(mic *audio.Microphone, buf *pitch.Buffer, port *serial.Port, stop chan os.Signal) {
+	fmt.Println("Listening... (Ctrl+C to stop)")
+
 	for {
 		select {
 		case <-stop:
-			fmt.Println("\nStopped")
+			fmt.Println("\nStopped.")
 			return
 		default:
-			frame, err := mic.Read()
-			if err != nil {
-				log.Printf("failed to read audio: %v", err)
+			note, ok := readNote(mic, buf)
+			if !ok {
 				continue
 			}
-
-			result := pitch.Autocorrelation(frame)
-			if result.Frequency == 0.0 {
-				continue
-			}
-
-			buf.Add(result)
-
-			avgFreq := buf.Average()
-			if avgFreq == 0.0 {
-				continue
-			}
-
-			note := music.FromFrequency(avgFreq)
 
 			fmt.Printf("Frequency: %.2f Hz | Note: %s%d | Cents: %.2f\n",
 				note.Frequency,
@@ -71,10 +75,129 @@ func main() {
 				note.Cents,
 			)
 
-			err = port.Send(note.Name, note.Octave, note.Cents)
-			if err != nil {
-				log.Printf("failed to send to Arduino: %v", err)
+			if port != nil {
+				if err := port.Send(note.Name, note.Octave, note.Cents); err != nil {
+					log.Printf("failed to send to Arduino: %v", err)
+				}
 			}
 		}
 	}
+}
+
+func runTunerMode(mic *audio.Microphone, buf *pitch.Buffer, port *serial.Port, stop chan os.Signal, threshold float64) {
+	inputCh := make(chan string)
+
+	readInput := func() {
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			inputCh <- scanner.Text()
+		}
+		close(inputCh)
+	}
+
+	go readInput()
+
+	promptNext := make(chan struct{}, 1)
+	promptNext <- struct{}{}
+
+	for {
+		select {
+		case <-stop:
+			fmt.Println("\nStopped.")
+			return
+		case <-promptNext:
+			fmt.Print("Enter target note (e.g. A4) or type 'q' to quit: ")
+			input, ok := <-inputCh
+			if !ok {
+				return
+			}
+
+			if strings.TrimSpace(input) == "q" {
+				fmt.Println("Stopped.")
+				return
+			}
+
+			input = strings.TrimSpace(input)
+			name, octave, err := music.ParseNote(input)
+			if err != nil {
+				fmt.Printf("Invalid note: %v\n", err)
+				promptNext <- struct{}{}
+				continue
+			}
+
+			targetFreq, err := music.ToFrequency(name, octave)
+			if err != nil {
+				fmt.Printf("Invalid note: %v\n", err)
+				promptNext <- struct{}{}
+				continue
+			}
+
+			targetLabel := fmt.Sprintf("%s%d", name, octave)
+			fmt.Printf("Tuning to %s (%.2f Hz)...\n", targetLabel, targetFreq)
+
+			go func(label string, freq float64) {
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						note, ok := readNote(mic, buf)
+						if !ok {
+							continue
+						}
+
+						centsFromTarget := centsBetween(note.Frequency, freq)
+
+						fmt.Printf("\rTarget: %s | Frequency: %.2f Hz | Cents: %+.2f   ",
+							label,
+							note.Frequency,
+							centsFromTarget,
+						)
+
+						if port != nil {
+							if err := port.Send(note.Name, note.Octave, centsFromTarget); err != nil {
+								log.Printf("failed to send to Arduino: %v", err)
+							}
+						}
+
+						if centsFromTarget >= -threshold && centsFromTarget <= threshold {
+							fmt.Printf("\nNote %s is in tune. Press Enter to confirm and continue.", label)
+							<-inputCh
+							promptNext <- struct{}{}
+							return
+						}
+					}
+				}
+			}(targetLabel, targetFreq)
+		}
+	}
+}
+
+func readNote(mic *audio.Microphone, buf *pitch.Buffer) (music.Note, bool) {
+	frame, err := mic.Read()
+	if err != nil {
+		log.Printf("failed to read audio: %v", err)
+		return music.Note{}, false
+	}
+
+	result := pitch.Autocorrelation(frame)
+	if result.Frequency == 0.0 {
+		return music.Note{}, false
+	}
+
+	buf.Add(result)
+	avgFreq := buf.Average()
+	if avgFreq == 0.0 {
+		return music.Note{}, false
+	}
+
+	return music.FromFrequency(avgFreq), true
+}
+
+func centsBetween(detected, target float64) float64 {
+	return 1200.0 * log2(target/detected)
+}
+
+func log2(x float64) float64 {
+	return math.Log2(x)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/kaidi-ahas/ranan
 
 go 1.25.5
 
-require github.com/gordonklaus/portaudio v0.0.0-20260203164431-765aa7dfa631
-
 require (
-	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	github.com/gordonklaus/portaudio v0.0.0-20260203164431-765aa7dfa631
+	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
 )
+
+require golang.org/x/sys v0.42.0 // indirect

--- a/internal/music/target.go
+++ b/internal/music/target.go
@@ -1,0 +1,51 @@
+package music
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+)
+
+func ParseNote(input string) (string, int, error) {
+	if len(input) < 2 {
+		return "", 0, fmt.Errorf("invalid note: %s", input)
+	}
+
+	var nameEnd int
+	if len(input) > 2 && input[1] == '#' {
+		nameEnd = 2
+	} else {
+		nameEnd = 1
+	}
+
+	name := input[:nameEnd]
+	octaveStr := input[nameEnd:]
+
+	octave, err := strconv.Atoi(octaveStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid octave in note: %s", input)
+	}
+	
+	return name, octave, nil
+}
+
+func ToFrequency (name string, octave int) (float64, error) {
+
+	index := -1
+	
+	for i, n := range noteNames {
+		if n == name {
+			index = i
+			break
+		}
+	}
+
+	if index == -1 {
+		return 0, fmt.Errorf("unknown note name: %s", name)
+	}
+
+	midi := (octave+1)*12 + index
+	freq := 440 * math.Pow(2.0, float64(midi-69)/12.0)
+
+	return freq, nil
+}

--- a/internal/music/target_test.go
+++ b/internal/music/target_test.go
@@ -1,0 +1,72 @@
+package music
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseNote_C4(t *testing.T) {
+	name, octave, err := ParseNote("C4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if name != "C" {
+		t.Errorf("expected name C, got %s", name)
+	}
+
+	if octave != 4 {
+		t.Errorf("expected octave 4, got %d", octave)
+	}
+}
+
+func TestParseNote_Sharp(t *testing.T) {
+	name, octave, err := ParseNote("C#4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "C#" {
+		t.Errorf("expected name C#, got %s", name)
+	}
+
+	if octave != 4 {
+		t.Errorf("expected octave 4, got %d", octave)
+	}
+}
+
+func TestParseNote_Invalid(t *testing.T) {
+	_, _, err := ParseNote("X")
+	if err == nil {
+		t.Error("expected error for invalid note, got nil")
+	}
+}
+
+func TestToFrequency_A4(t *testing.T) {
+	freq, err := ToFrequency("A", 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(freq-440) > 0.01 {
+		t.Errorf("expected 440.0, got %f", freq)
+	}
+}
+
+func TestToFrequency_C4(t *testing.T) {
+	freq, err := ToFrequency("C", 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if math.Abs(freq-261.63) > 0.01 {
+		t.Errorf("expected ~261.63, got %f", freq)
+	}
+}
+
+func TestToFrequency_UnknownNote(t *testing.T) {
+	_, err := ToFrequency("X", 4)
+	if err == nil {
+		t.Fatal("expected error for unknown note, got nil")
+	}
+}
+
+
+

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ The system captures microphone audio, detects the fundamental frequency, convert
 - Note name and octave indentification
 - Cent deviation calculation from equal temperament
 - Serial communication to Arduino for hardware LED tuner display
+- Tuner mode with sequential note input and in-place display
 
 ---
 
@@ -82,6 +83,32 @@ Frequency: 438.80 Hz | Note: A4 | Cents: -2.23
 Press Ctrl+C to stop.
 
 ---
+
+## Tuner Mode
+
+To enable tuner mode, pass the `--tuner` flag:
+```
+go run cmd/ranan/main.go --tuner
+```
+
+The program will prompt for a target note, then listen and display cent deviation from that target in real time on a single updating line:
+```
+Target: A4 | Frequency: 441.20 Hz | Cents: +4.71
+```
+
+When the pitch is within threshold, the program confirms:
+```
+Note A4 is in tune. Press Enter to confirm and continue.
+```
+
+To use a custom threshold in cents:
+```
+go run cmd/ranan/main.go --tuner --threshold=5
+```
+
+Default threshold is 10 cents.
+
+To quit, type `q` at the note prompt and press Enter.
 
 ## Running the API
 ```bash


### PR DESCRIPTION
Closes #24 

## What this does
- Adds ParseNote and ToFrequency functions to internal/music/
- Adds --tuner flag to enable tuner mode
- Adds --threshold flag with default of 10 cents
- Prompts user for target note at startup
- Updates single line in place using carriage return
- Prints in-tune message when pitch is within threshold
- Prompts for next target note after confirmation 
- Typing 'q' at the note prompt exits the program
- Makes Arduino serial connection optional (warns if not connected)
- Updates README with tuner mode usage and flags

## Known limitations
Ctrl+C does not work while waiting for note input at the prompt.
User must type 'q' to exit at that stage.
A follow-up issue will be created to fix this properly.

## Verified
- Free-running mode behavior unchanged
- Tuner mode updates line in place
- In-tune message appears within threshold
- Custom threshold works via --threshold flag
- Ctrl+C exits cleanly during pitch detection
- 'q' exits cleanly at the note prompt