### PR TITLE
feat(serial): dynamic Arduino port detection with --port flag override

### DIFF
--- a/arduino/tuner/tuner.ino
+++ b/arduino/tuner/tuner.ino
@@ -21,18 +21,17 @@ void loop() {
             return;
         }
 
-        String noteStr = message.substring(0, commaIndex);
-        float cents    = message.substring(commaIndex + 1).toFloat();
+        String status = message.substring(commaIndex +1);
 
         digitalWrite(PIN_LED_LEFT,  LOW);
         digitalWrite(PIN_LED_GREEN, LOW);
         digitalWrite(PIN_LED_RIGHT, LOW);
 
-        if (cents < -TUNE_THRESHOLD) {
+        if (status == "flat") {
             digitalWrite(PIN_LED_LEFT, HIGH);
-        } else if (cents > TUNE_THRESHOLD) {
+        } else if (status == "sharp") {
             digitalWrite(PIN_LED_RIGHT, HIGH);
-        } else {
+        } else if (status == "intune") {
             digitalWrite(PIN_LED_GREEN, HIGH);
         }
     }

--- a/cmd/ranan/free.go
+++ b/cmd/ranan/free.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/kaidi-ahas/ranan/internal/audio"
+	"github.com/kaidi-ahas/ranan/internal/music"
+	"github.com/kaidi-ahas/ranan/internal/pitch"
+	"github.com/kaidi-ahas/ranan/internal/serial"
+)
+
+func RunFreeMode(mic *audio.Microphone, buf *pitch.Buffer, port *serial.Port, stop chan os.Signal) {
+	fmt.Println("Listening... (Ctrl+C to stop)")
+
+	for {
+		select {
+		case <-stop:
+			fmt.Println("\nStopped.")
+			return
+		default:
+			note, ok := ReadNote(mic, buf)
+			if !ok {
+				continue
+			}
+
+			fmt.Printf("Frequency: %.2f Hz | Note: %s%d | Cents: %.2f\n",
+				note.Frequency,
+				note.Name,
+				note.Octave,
+				note.Cents,
+			)
+
+			if port != nil {
+				status := music.TuningStatus(note.Cents, 10.0)
+				if err := port.Send(note.Name, note.Octave, status); err != nil {
+					log.Printf("failed to send to Arduino: %v", err)
+				}
+			}
+		}
+	}
+}
+
+func ReadNote(mic *audio.Microphone, buf *pitch.Buffer) (music.Note, bool) {
+	frame, err := mic.Read()
+	if err != nil {
+		log.Printf("failed to read audio: %v", err)
+		return music.Note{}, false
+	}
+
+	result := pitch.Autocorrelation(frame)
+	if result.Frequency == 0.0 {
+		return music.Note{}, false
+	}
+
+	buf.Add(result)
+	avgFreq := buf.Average()
+	if avgFreq == 0.0 {
+		return music.Note{}, false
+	}
+
+	return music.FromFrequency(avgFreq), true
+}

--- a/cmd/ranan/main.go
+++ b/cmd/ranan/main.go
@@ -1,30 +1,22 @@
 package main
 
 import (
-	"bufio"
 	"flag"
-	"fmt"
 	"log"
-	"math"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/kaidi-ahas/ranan/internal/audio"
-	"github.com/kaidi-ahas/ranan/internal/music"
 	"github.com/kaidi-ahas/ranan/internal/pitch"
-	"github.com/kaidi-ahas/ranan/internal/serial"
 )
 
-const (
-	bufferSize  = 5
-	arduinoPort = "/dev/cu.usbmodem11301"
-)
+const bufferSize  = 5
 
 func main() {
 	tunerMode := flag.Bool("tuner", false, "enable tuner mode")
 	threshold := flag.Float64("threshold", 10.0, "in-tune threshold in cents")
+	portFlag := flag.String("port", "", "Arduino serial port (auto-detected if not set)")
 	flag.Parse()
 
 	mic, err := audio.NewMicrophone()
@@ -33,11 +25,7 @@ func main() {
 	}
 	defer mic.Close()
 
-	port, err := serial.Open(arduinoPort)
-	if err != nil {
-		log.Printf("warning: Arduino not connected, serial disabled: %v", err)
-		port = nil
-	}
+	port := OpenSerial(*portFlag)
 	if port != nil {
 		defer port.Close()
 	}
@@ -48,156 +36,8 @@ func main() {
 	buf := pitch.NewBuffer(bufferSize)
 
 	if *tunerMode {
-		runTunerMode(mic, buf, port, stop, *threshold)
+		RunTunerMode(mic, buf, port, stop, *threshold)
 	} else {
-		runFreeMode(mic, buf, port, stop)
+		RunFreeMode(mic, buf, port, stop)
 	}
-}
-
-func runFreeMode(mic *audio.Microphone, buf *pitch.Buffer, port *serial.Port, stop chan os.Signal) {
-	fmt.Println("Listening... (Ctrl+C to stop)")
-
-	for {
-		select {
-		case <-stop:
-			fmt.Println("\nStopped.")
-			return
-		default:
-			note, ok := readNote(mic, buf)
-			if !ok {
-				continue
-			}
-
-			fmt.Printf("Frequency: %.2f Hz | Note: %s%d | Cents: %.2f\n",
-				note.Frequency,
-				note.Name,
-				note.Octave,
-				note.Cents,
-			)
-
-			if port != nil {
-				if err := port.Send(note.Name, note.Octave, note.Cents); err != nil {
-					log.Printf("failed to send to Arduino: %v", err)
-				}
-			}
-		}
-	}
-}
-
-func runTunerMode(mic *audio.Microphone, buf *pitch.Buffer, port *serial.Port, stop chan os.Signal, threshold float64) {
-	inputCh := make(chan string)
-
-	readInput := func() {
-		scanner := bufio.NewScanner(os.Stdin)
-		for scanner.Scan() {
-			inputCh <- scanner.Text()
-		}
-		close(inputCh)
-	}
-
-	go readInput()
-
-	promptNext := make(chan struct{}, 1)
-	promptNext <- struct{}{}
-
-	for {
-		select {
-		case <-stop:
-			fmt.Println("\nStopped.")
-			return
-		case <-promptNext:
-			fmt.Print("Enter target note (e.g. A4) or type 'q' to quit: ")
-			input, ok := <-inputCh
-			if !ok {
-				return
-			}
-
-			if strings.TrimSpace(input) == "q" {
-				fmt.Println("Stopped.")
-				return
-			}
-
-			input = strings.TrimSpace(input)
-			name, octave, err := music.ParseNote(input)
-			if err != nil {
-				fmt.Printf("Invalid note: %v\n", err)
-				promptNext <- struct{}{}
-				continue
-			}
-
-			targetFreq, err := music.ToFrequency(name, octave)
-			if err != nil {
-				fmt.Printf("Invalid note: %v\n", err)
-				promptNext <- struct{}{}
-				continue
-			}
-
-			targetLabel := fmt.Sprintf("%s%d", name, octave)
-			fmt.Printf("Tuning to %s (%.2f Hz)...\n", targetLabel, targetFreq)
-
-			go func(label string, freq float64) {
-				for {
-					select {
-					case <-stop:
-						return
-					default:
-						note, ok := readNote(mic, buf)
-						if !ok {
-							continue
-						}
-
-						centsFromTarget := centsBetween(note.Frequency, freq)
-
-						fmt.Printf("\rTarget: %s | Frequency: %.2f Hz | Cents: %+.2f   ",
-							label,
-							note.Frequency,
-							centsFromTarget,
-						)
-
-						if port != nil {
-							if err := port.Send(note.Name, note.Octave, centsFromTarget); err != nil {
-								log.Printf("failed to send to Arduino: %v", err)
-							}
-						}
-
-						if centsFromTarget >= -threshold && centsFromTarget <= threshold {
-							fmt.Printf("\nNote %s is in tune. Press Enter to confirm and continue.", label)
-							<-inputCh
-							promptNext <- struct{}{}
-							return
-						}
-					}
-				}
-			}(targetLabel, targetFreq)
-		}
-	}
-}
-
-func readNote(mic *audio.Microphone, buf *pitch.Buffer) (music.Note, bool) {
-	frame, err := mic.Read()
-	if err != nil {
-		log.Printf("failed to read audio: %v", err)
-		return music.Note{}, false
-	}
-
-	result := pitch.Autocorrelation(frame)
-	if result.Frequency == 0.0 {
-		return music.Note{}, false
-	}
-
-	buf.Add(result)
-	avgFreq := buf.Average()
-	if avgFreq == 0.0 {
-		return music.Note{}, false
-	}
-
-	return music.FromFrequency(avgFreq), true
-}
-
-func centsBetween(detected, target float64) float64 {
-	return 1200.0 * log2(target/detected)
-}
-
-func log2(x float64) float64 {
-	return math.Log2(x)
 }

--- a/cmd/ranan/serial.go
+++ b/cmd/ranan/serial.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/kaidi-ahas/ranan/internal/serial"
+)
+
+
+func OpenSerial(portFlag string) *serial.Port {
+	device := portFlag
+
+	if device == "" {
+		detected, err := serial.DetectPort("/dev/cu.usbmodem*")
+		if err != nil {
+			log.Printf("warning: no Arduino port detected, serial disabled")
+			return nil
+		}
+		fmt.Printf("Arduino detected on %s\n", detected)
+		device = detected
+	}
+
+	port, err := serial.Open(device)
+	if err != nil {
+		log.Printf("warning: failed to open serial port %s, serial disabled: %v", device, err)
+		return nil
+	}
+
+	return port
+}

--- a/cmd/ranan/tuner.go
+++ b/cmd/ranan/tuner.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/kaidi-ahas/ranan/internal/audio"
+	"github.com/kaidi-ahas/ranan/internal/music"
+	"github.com/kaidi-ahas/ranan/internal/pitch"
+	"github.com/kaidi-ahas/ranan/internal/serial"
+)
+
+func RunTunerMode(mic *audio.Microphone, buf *pitch.Buffer, port *serial.Port, stop chan os.Signal, threshold float64) {
+	inputCh := make(chan string)
+
+	readInput := func() {
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			inputCh <- scanner.Text()
+		}
+		close(inputCh)
+	}
+
+	go readInput()
+
+	promptNext := make(chan struct{}, 1)
+	promptNext <- struct{}{}
+
+	for {
+		select {
+		case <-stop:
+			fmt.Println("\nStopped.")
+			return
+		case <-promptNext:
+			fmt.Print("Enter target note (e.g. A4) or type 'q' to quit: ")
+			input, ok := <-inputCh
+			if !ok {
+				return
+			}
+
+			if strings.TrimSpace(input) == "q" {
+				fmt.Println("Stopped.")
+				return
+			}
+
+			input = strings.TrimSpace(input)
+			name, octave, err := music.ParseNote(input)
+			if err != nil {
+				fmt.Printf("Invalid note: %v\n", err)
+				promptNext <- struct{}{}
+				continue
+			}
+
+			targetFreq, err := music.ToFrequency(name, octave)
+			if err != nil {
+				fmt.Printf("Invalid note: %v\n", err)
+				promptNext <- struct{}{}
+				continue
+			}
+
+			targetLabel := fmt.Sprintf("%s%d", name, octave)
+			fmt.Printf("Tuning to %s (%.2f Hz)...\n", targetLabel, targetFreq)
+
+			go func(label string, freq float64) {
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						note, ok := ReadNote(mic, buf)
+						if !ok {
+							continue
+						}
+
+						centsFromTarget := music.CentsBetween(note.Frequency, freq)
+
+						fmt.Printf("\rTarget: %s | Frequency: %.2f Hz | Cents: %+.2f   ",
+							label,
+							note.Frequency,
+							centsFromTarget,
+						)
+
+						if port != nil {
+							status := music.TuningStatus(centsFromTarget, threshold)
+							if err := port.Send(note.Name, note.Octave, status); err != nil {
+								log.Printf("failed to send to Arduino: %v", err)
+							}
+						}
+
+						if centsFromTarget >= -threshold && centsFromTarget <= threshold {
+							fmt.Printf("\nNote %s is in tune. Press Enter to confirm and continue.", label)
+							<-inputCh
+							promptNext <- struct{}{}
+							return
+						}
+					}
+				}
+			}(targetLabel, targetFreq)
+		}
+	}
+}

--- a/internal/music/target.go
+++ b/internal/music/target.go
@@ -49,3 +49,17 @@ func ToFrequency (name string, octave int) (float64, error) {
 
 	return freq, nil
 }
+
+func CentsBetween(detected, target float64) float64 {
+	return 1200.0 * math.Log2(target/detected)
+}
+
+func TuningStatus(cents, threshold float64) string {
+	if cents < -threshold {
+		return "flat"
+	}
+	if cents > threshold {
+		return "sharp"
+	}
+	return "intune"
+}

--- a/internal/music/target_test.go
+++ b/internal/music/target_test.go
@@ -68,5 +68,30 @@ func TestToFrequency_UnknownNote(t *testing.T) {
 	}
 }
 
+func TestCentsBetween_Unison(t *testing.T) {
+	cents := CentsBetween(440.0, 880.0)
+	if math.Abs(cents-1200.0) > 0.01 {
+		t.Errorf("expected 1200 cents for one octave, got %.2f", cents)
+	}
+}
 
+func TestTuningStatus_Flat(t *testing.T) {
+	status := TuningStatus(-15.0, 10.0)
+	if status != "flat" {
+		t.Errorf("expected flat, got %s", status)
+	}
+}
 
+func TestTuningStatus_InTune(t *testing.T) {
+	status := TuningStatus(3.0, 10.0)
+	if status != "intune" {
+		t.Errorf("expected intune, got %s", status)
+	}
+}
+
+func TestTuningStatus_Sharp(t *testing.T) {
+	status := TuningStatus(15.0, 10.0)
+	if status != "sharp" {
+		t.Errorf("expected sharp, got %s", status)
+	}
+}

--- a/internal/serial/detect.go
+++ b/internal/serial/detect.go
@@ -1,0 +1,19 @@
+package serial
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+func DetectPort(pattern string) (string, error) {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", fmt.Errorf("failed to scan for Arduino port: %w", err)
+	}
+
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no Arduino port found matching %s", pattern)
+	}
+
+	return matches[0], nil
+}

--- a/internal/serial/detect_test.go
+++ b/internal/serial/detect_test.go
@@ -1,0 +1,33 @@
+package serial
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDetectPort_FindsMatch(t *testing.T) {
+	dir := t.TempDir()
+	fakePort := dir + "/cu.usbmodem1234"
+	f, err := os.Create(fakePort)
+	if err != nil {
+		t.Fatalf("failed to create fake port file: %v", err)
+	}
+	f.Close()
+
+	port, err := DetectPort(dir + "/cu.usbmodem*")
+	if err != nil {
+		t.Fatalf("expected %s, got %s", fakePort, port)
+	}
+	if port != fakePort {
+		t.Errorf("expected %s, got %s", fakePort, port)
+	}
+}
+
+func TestDetectPort_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := DetectPort(dir + "/cu.usbmodem*")
+	if err == nil {
+		t.Error("expected error when no port found, got nil")
+	}
+}

--- a/internal/serial/serial.go
+++ b/internal/serial/serial.go
@@ -2,13 +2,15 @@ package serial
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/tarm/serial"
 )
 
 
 type Port struct {
-	port *serial.Port
+	writer io.Writer
+	closer io.Closer
 }
 
 func Open(device string) (*Port, error) {
@@ -22,13 +24,13 @@ func Open(device string) (*Port, error) {
 		return nil, fmt.Errorf("failed to open serial port %s: %w", device, err)
 	}
 
-	return &Port{port: port}, nil
+	return &Port{writer: port, closer: port}, nil
 }
 
-func (p *Port) Send(note string, octave int, cents float64) error {
-	message := fmt.Sprintf("%s%d, %.2f\n", note, octave, cents)
+func (p *Port) Send(note string, octave int, status string) error {
+	message := fmt.Sprintf("%s%d,%s\n", note, octave, status)
 
-	_, err := p.port.Write([]byte(message))
+	_, err := p.writer.Write([]byte(message))
 	if err != nil {
 		return fmt.Errorf("failed to write to serial port: %w", err)
 	}
@@ -37,5 +39,5 @@ func (p *Port) Send(note string, octave int, cents float64) error {
 }
 
 func (p *Port) Close() error {
-	return p.port.Close()
+	return p.closer.Close()
 }

--- a/internal/serial/serial_test.go
+++ b/internal/serial/serial_test.go
@@ -1,0 +1,58 @@
+package serial
+
+import (
+	"strings"
+	"testing"
+)
+
+type fakeWriter struct {
+	written string
+}
+
+func (f *fakeWriter) Write(p []byte) (int, error) {
+	f.written += string(p)
+	return len(p), nil
+}
+
+func newTestPort(w *fakeWriter) *Port {
+	return &Port{writer: w}
+}
+
+func TestSend_Flat(t *testing.T) {
+	w := &fakeWriter{}
+	p := newTestPort(w)
+
+	err := p.Send("A", 4, "flat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(w.written, "A4,flat") {
+		t.Errorf("expected message to contain A4,flat, got %s", w.written)
+	}
+}
+
+func TestSent_InTune(t *testing.T) {
+	w := &fakeWriter{}
+	p := newTestPort(w)
+
+	err := p.Send("A", 4, "intune")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(w.written, "A4,intune") {
+		t.Errorf("expected message to contain A4,intune, got %s", w.written)
+	}
+}
+
+func TestSent_Sharp(t *testing.T) {
+	w := &fakeWriter{}
+	p := newTestPort(w)
+
+	err := p.Send("A", 4, "sharp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(w.written, "A4,sharp") {
+		t.Errorf("expected message to contain A4,sharp, got %s", w.written)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # Ranan
 
-Ranan is a pitch detection and musical feedback engine written in Go.
+Ranan is a pitch detection, musical feedback, and tuning engine written in Go.
 
-The system captures microphone audio, detects the fundamental frequency, converts it to a musical note, and calculates cent deviation from equal temperament tuning.
+The system captures microphone audio, detects the fundamental frequency, converts it to a musical note, calculates cent deviation from equal temperament tuning, and provides real-time feedback via CLI and Arduino LED indicator.
 
 ---
 
@@ -14,18 +14,22 @@ The system captures microphone audio, detects the fundamental frequency, convert
 - Frequency → MIDI note conversion
 - Note name and octave indentification
 - Cent deviation calculation from equal temperament
-- Serial communication to Arduino for hardware LED tuner display
 - Tuner mode with sequential note input and in-place display
+- Serial communication to Arduino for hardware LED tuner display
+- Auto-detection of Arduino serial port
+
 
 ---
 
 ## Architecture
 ```
 cmd/api/          — HTTP server
-cmd/ranan/        — CLI feedback tool
+cmd/ranan/        — CLI tuner and feedback tool
 internal/audio/   — microphone capture
 internal/pitch/   — pitch detection and analysis
-internal/music/   — frequency to note conversion
+internal/music/   — frequency to note conversion and tuning logic
+internal/serial   — Arduino serial communication
+arduino/tuner/    - Arduino LED tuner firmware
 ```
 
 ---
@@ -50,26 +54,42 @@ sudo apt-get install portaudio19-dev
 
 ## Arduino Setup
 
-The CLI can send pitch data to an Arduino over USB serial.
+Connect an Arduino UNO via USB and upload the firmware from `arduino/tuner/tuner.ino` using Arduino IDE.
+
+The CLI auto-detects the Arduino port on startup:
+```
+Arduino detected on /dev/cu.usbmodem11301
+```
+
+To override the detected port use the `--port` flag:
+```
+go run cmd/ranan/main.go --port=/dev/usbmodem11301
+```
+
+If no Arduino is connected, serial is disabled automatically and the program continues without it.
 
 The Arduino receives messages in this format:
 ```
-A4,0.79
+A4,intune
+A4,flat
+A4,sharp
 ```
 
-Where the first part is the note name and octave, and the second part is the cent deviation.
+### LED behavior
 
-To use this feature:
-1. Connect Arduino UNO to your Mac via USB
-2. Upload the Arduino firmware (see arduino/ directory)
-3. Confirm the port name with: `ls /dev/cu.*`
-4. Update the `arduinoPort` constant in `cmd/ranan/main.go`
+| Status | LED |
+|--------|-----|
+| flat (cents < −threshold) | Left red LED |
+| intune (within threshold) | Green LED |
+| sharp (cents > +threshold) | Right red LED |
 
 ---
 
 ## Running the CLI
+
+Free-running mode - detects and displays whatever note is played:
 ```bash
-go run cmd/ranan/main.go
+go run ./cmd/ranan/
 ```
 
 Example output:
@@ -86,12 +106,12 @@ Press Ctrl+C to stop.
 
 ## Tuner Mode
 
-To enable tuner mode, pass the `--tuner` flag:
+Tuner mode prompts for a target note and gives real-time feedback against it:
 ```
 go run cmd/ranan/main.go --tuner
 ```
 
-The program will prompt for a target note, then listen and display cent deviation from that target in real time on a single updating line:
+The program updates a single line in place:
 ```
 Target: A4 | Frequency: 441.20 Hz | Cents: +4.71
 ```
@@ -106,29 +126,10 @@ To use a custom threshold in cents:
 go run cmd/ranan/main.go --tuner --threshold=5
 ```
 
-Default threshold is 10 cents.
+Default threshold is 10 cents. The Arduino LEDs reflect the same threshold as the CLI.
 
 To quit, type `q` at the note prompt and press Enter.
 
-## Running the API
-```bash
-go run cmd/api/main.go
-```
-
-The API runs on:
-```
-http://localhost:8080
-```
-
-Health check:
-```
-GET /health
-```
-
-Expected response:
-```
-OK
-```
 
 ## Running Tests
 ```bash


### PR DESCRIPTION
Closes #27 

## What this does
- Splits cmd/ranan/main.go into main.go, free.go, tuner.go, serial.go
- Adds auto-detection of Arduino port matching /dev/cu.usbmodem*
- Prints detected port name on startup
- Adds --port flag to override auto-detected port
- Refactors Port to use io.Writer for testability
- Changes serial message format from raw cents to tuning status string
- Adds TuningStatus function to internal/music/
- Updates Arduino firmware to receive status string instead of float
- Arduino LEDs now always reflect the same threshold as the CLI
- Updates README with current features, architecture and usage

## Message format
Before: A4,0.79
After: A7,intune

## Verified
- Auto-detection works when Arduino is connected
- Warning printed when no Arduino is detected 
- --port flag overrides auto-detection
- Arduino LEDs respond correctly to flat, intune, sharp
- All tests pass